### PR TITLE
Sanitize phone numbers

### DIFF
--- a/Komando/GR02.js
+++ b/Komando/GR02.js
@@ -178,12 +178,13 @@ function getTargetPhone(rawPhone) {
 function formatPhone(num) {
   if (!num) return '';
   num = num.toString().trim();
+  num = num.replace(/\D/g, '');
   if (num.startsWith('+628')) {
-    return '628' + num.substring(4);
+    num = '628' + num.substring(4);
   } else if (num.startsWith('08')) {
-    return '628' + num.substring(2);
+    num = '628' + num.substring(2);
   } else if (num.startsWith('628')) {
-    return num;
+    // already in correct format
   }
   return num;
 }

--- a/Komando/SendReport.gs
+++ b/Komando/SendReport.gs
@@ -178,12 +178,13 @@ function getTargetPhone(rawPhone) {
 function formatPhone(num) {
   if (!num) return '';
   num = num.toString().trim();
+  num = num.replace(/\D/g, '');
   if (num.startsWith('+628')) {
-    return '628' + num.substring(4);
+    num = '628' + num.substring(4);
   } else if (num.startsWith('08')) {
-    return '628' + num.substring(2);
+    num = '628' + num.substring(2);
   } else if (num.startsWith('628')) {
-    return num;
+    // already in correct format
   }
   return num;
 }


### PR DESCRIPTION
## Summary
- Strip non-digit characters in `formatPhone` before applying existing prefix logic.
- Preserve checks for `+628`, `08`, and `628` prefixes and return the sanitized number.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd91d827408325b242e0d7d20930b9